### PR TITLE
Fix: add macOS field to PlatformPolicy

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 * **Fix:** "Remind later" and "dismissed" no longer count as a shown prompt. Previously, platform policy, cooldown, and max prompts counters were incremented before the dialog was shown — burning a prompt slot even when the user didn't engage. Now, counters are only updated on positive or negative responses.
 * **Breaking:** Debug mode no longer bypasses prerequisites, platform policy, or conditions. It now only enables detailed logging via `debugPrint`. Use a relaxed `PlatformPolicy` to test the dialog flow during development.
 * **Fix:** `reset()` now re-records the install date after clearing storage, so `MinDaysAfterInstall` continues to work correctly after a reset.
+* **Fix:** `PlatformPolicy` now includes a `macOS` field with iOS defaults. Previously macOS silently fell back to Android rules.
 
 ## 0.1.0
 

--- a/README.md
+++ b/README.md
@@ -332,6 +332,11 @@ platformPolicy: const PlatformPolicy(
     maxPrompts: 3,
     maxPromptsPeriod: Duration(days: 365),
   ),
+  macOS: PlatformRules(
+    cooldown: Duration(days: 120),
+    maxPrompts: 3,
+    maxPromptsPeriod: Duration(days: 365),
+  ),
 )
 ```
 
@@ -460,6 +465,11 @@ platformPolicy: const PlatformPolicy(
     maxPromptsPeriod: Duration(days: 365),
   ),
   ios: PlatformRules(
+    cooldown: Duration(seconds: 10),
+    maxPrompts: 99,
+    maxPromptsPeriod: Duration(days: 365),
+  ),
+  macOS: PlatformRules(
     cooldown: Duration(seconds: 10),
     maxPrompts: 99,
     maxPromptsPeriod: Duration(days: 365),

--- a/example/lib/main.dart
+++ b/example/lib/main.dart
@@ -34,6 +34,11 @@ void main() async {
         maxPrompts: 99,
         maxPromptsPeriod: Duration(days: 365),
       ),
+      macOS: PlatformRules(
+        cooldown: Duration(seconds: 10),
+        maxPrompts: 99,
+        maxPromptsPeriod: Duration(days: 365),
+      ),
     ),
     dialogAdapter: DefaultReviewDialogAdapter(
       preDialogConfig: const DefaultPreDialogConfig(

--- a/example/pubspec.lock
+++ b/example/pubspec.lock
@@ -104,7 +104,7 @@ packages:
     source: path
     version: "0.1.0"
   in_app_review:
-    dependency: transitive
+    dependency: "direct dev"
     description:
       name: in_app_review
       sha256: ab26ac54dbd802896af78c670b265eaeab7ecddd6af4d0751e9604b60574817f

--- a/example/pubspec.yaml
+++ b/example/pubspec.yaml
@@ -18,6 +18,7 @@ dev_dependencies:
   flutter_test:
     sdk: flutter
   flutter_lints: ^5.0.0
+  in_app_review: ^2.0.10
   mocktail: ^1.0.4
 
 flutter:

--- a/example/test/e2e_review_flow_test.dart
+++ b/example/test/e2e_review_flow_test.dart
@@ -94,6 +94,11 @@ void main() {
             maxPrompts: 99,
             maxPromptsPeriod: Duration(days: 365),
           ),
+          macOS: PlatformRules(
+            cooldown: Duration(seconds: 10),
+            maxPrompts: 99,
+            maxPromptsPeriod: Duration(days: 365),
+          ),
         ),
         dialogAdapter: dialogAdapter,
         debugMode: true,

--- a/lib/src/models/platform_policy.dart
+++ b/lib/src/models/platform_policy.dart
@@ -7,15 +7,18 @@ import 'dart:io' show Platform;
 class PlatformPolicy {
   final PlatformRules android;
   final PlatformRules ios;
+  final PlatformRules macOS;
 
   const PlatformPolicy({
     this.android = const PlatformRules.androidDefaults(),
     this.ios = const PlatformRules.iosDefaults(),
+    this.macOS = const PlatformRules.iosDefaults(),
   });
 
   /// Returns the rules for the current platform.
   PlatformRules get current {
     if (Platform.isIOS) return ios;
+    if (Platform.isMacOS) return macOS;
     return android;
   }
 }

--- a/test/happy_review_instance_test.dart
+++ b/test/happy_review_instance_test.dart
@@ -22,6 +22,11 @@ void main() {
       maxPrompts: 999,
       maxPromptsPeriod: Duration(days: 365),
     ),
+    macOS: PlatformRules(
+      cooldown: Duration.zero,
+      maxPrompts: 999,
+      maxPromptsPeriod: Duration(days: 365),
+    ),
   );
 
   setUpAll(() {

--- a/test/platform_policy_checker_test.dart
+++ b/test/platform_policy_checker_test.dart
@@ -1,3 +1,5 @@
+import 'dart:io' show Platform;
+
 import 'package:flutter_test/flutter_test.dart';
 import 'package:happy_review/happy_review.dart';
 import 'package:happy_review/src/platform_policy_checker.dart';
@@ -194,6 +196,61 @@ void main() {
 
         // Then
         expect(result, isTrue);
+      },
+    );
+  });
+
+  group('PlatformPolicy', () {
+    test(
+      'Given default PlatformPolicy, '
+      'When accessing macOS rules, '
+      'Then returns iOS defaults (Apple platform)',
+      () {
+        const policy = PlatformPolicy();
+        final macRules = policy.macOS;
+        final iosRules = policy.ios;
+
+        expect(macRules.cooldown, equals(iosRules.cooldown));
+        expect(macRules.maxPrompts, equals(iosRules.maxPrompts));
+        expect(macRules.maxPromptsPeriod, equals(iosRules.maxPromptsPeriod));
+      },
+    );
+
+    test(
+      'Given custom macOS rules, '
+      'When creating PlatformPolicy, '
+      'Then macOS uses the custom rules',
+      () {
+        const customRules = PlatformRules(
+          cooldown: Duration(days: 30),
+          maxPrompts: 5,
+          maxPromptsPeriod: Duration(days: 180),
+        );
+        const policy = PlatformPolicy(macOS: customRules);
+
+        expect(policy.macOS.cooldown, equals(const Duration(days: 30)));
+        expect(policy.macOS.maxPrompts, equals(5));
+        expect(
+            policy.macOS.maxPromptsPeriod, equals(const Duration(days: 180)));
+      },
+    );
+
+    test(
+      'Given running on macOS, '
+      'When accessing current, '
+      'Then returns macOS rules',
+      () {
+        const macRules = PlatformRules(
+          cooldown: Duration(days: 45),
+          maxPrompts: 7,
+          maxPromptsPeriod: Duration(days: 200),
+        );
+        const policy = PlatformPolicy(macOS: macRules);
+
+        if (Platform.isMacOS) {
+          expect(policy.current.cooldown, equals(const Duration(days: 45)));
+          expect(policy.current.maxPrompts, equals(7));
+        }
       },
     );
   });


### PR DESCRIPTION
## Summary

- `PlatformPolicy` now includes an explicit `macOS` field that defaults to iOS rules (both Apple platforms).
- Previously, macOS silently fell back to Android defaults since `Platform.isMacOS` was not handled in the `current` getter.
- Updated README, example app, and all tests to include macOS rules.

## Type of change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Refactor (no functional changes)
- [ ] Documentation update

## Checklist

- [x] I have added tests that prove my fix is effective or that my feature works
- [x] All new and existing tests pass (`flutter test`)
- [x] Static analysis passes (`flutter analyze`)
- [x] I have updated the CHANGELOG
- [x] I have updated the README if the public API changed

Closes #18