### PR TITLE
ci: remove emoji from Unit Tests job name

### DIFF
--- a/.github/workflows/code-coverage.yml
+++ b/.github/workflows/code-coverage.yml
@@ -7,7 +7,7 @@ env:
 
 jobs:
   test_with_coverage:
-    name: 🧪 Unit Tests
+    name: Unit Tests
     runs-on: ubuntu-latest
     timeout-minutes: 20
 


### PR DESCRIPTION
## Summary

- Rename the CI job from `🧪 Unit Tests` to `Unit Tests` in `.github/workflows/code-coverage.yml`.
- Branch protection on `master` already updated to require the new check context `Unit Tests`.

## Why

Emoji in the job name couple the branch-protection `required_status_checks` to a glyph that's easy to mistype or break across tooling. Plain ASCII keeps the contract between CI and protection rules stable.

## Test plan

- [ ] CI green on the `Unit Tests` check
- [ ] PR mergeable once required status check passes