### PR TITLE
docs: adopt GitHub Flow and fix PR assignee

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -50,7 +50,7 @@ The example app is at `happy_review/example/` and can be run with `flutter run` 
 ## Critical Rules
 
 - Never add external storage dependencies to the library — use the adapter pattern (see ADR-002)
-- All PRs target `develop`, never `main`
+- All PRs target `master` (GitHub Flow — see ADR-006)
 - No `Co-Authored-By` lines in commits — this is a community open-source library
 - Library tests (`test/`) are for library internals only; example tests (`example/test/`) are for end-to-end scenarios
 - Update `doc/CURRENT_STATUS.md` at the end of every work session

--- a/doc/CONVENTIONS.md
+++ b/doc/CONVENTIONS.md
@@ -26,12 +26,14 @@
 
 ## Git & PR Conventions
 
-- **Base branch**: `develop` (all PRs target `develop`, not `main`)
+- **Workflow**: GitHub Flow — short-lived feature branches off `master`, PR back to `master` (see ADR-006)
+- **Base branch**: `master` (all PRs target `master`)
 - **Commit messages**: No `Co-Authored-By` lines — this is a community open-source library
-- **PR assignee**: Always `AMarturelo`
+- **PR assignee**: Always `albertomarturelo`
 - **PR project**: Always link to `Happy Review Roadmap` (#3)
 - **PR labels**: Carry over from linked issue
 - **PR template**: Located at `.github/PULL_REQUEST_TEMPLATE.md`
+- **Branch protection**: `master` requires 1 PR approval, `Unit Tests` check passing, conversations resolved, no force push, no deletion
 
 ## File Organization
 

--- a/doc/decisions/005-github-workflow-conventions.md
+++ b/doc/decisions/005-github-workflow-conventions.md
@@ -2,7 +2,7 @@
 
 ## Status
 
-Accepted
+Superseded by [ADR-006](006-adopt-github-flow.md) (base branch and assignee sections only; labels, template, and naming rules still apply)
 
 ## Date
 

--- a/doc/decisions/006-adopt-github-flow.md
+++ b/doc/decisions/006-adopt-github-flow.md
@@ -1,0 +1,44 @@
+# ADR-006: Adopt GitHub Flow
+
+## Status
+
+Accepted
+
+## Date
+
+2026-06-04
+
+## Context
+
+ADR-005 codified a Git Flow–style process: short-lived feature branches off `develop`, with `release/x.y.z` branches cut from `develop` and merged into `master` for publication. In practice this project is maintained by a single person, releases happen frequently, and the `develop` integration branch added overhead without delivering its main benefit (parallel feature integration ahead of a release window).
+
+Recent reality reinforces this: branch protection has now been applied to `master` only, the working branch in this repo is `master`, and PR #33 already merged directly to `master` without using `develop`. Keeping `develop` documented as the base branch would contradict the live protection rules and the actual flow.
+
+## Decision
+
+Adopt GitHub Flow:
+
+1. `master` is the single long-lived branch and the source of truth.
+2. Branch off `master` for every change using the prefixes from ADR-005 (`fix/`, `feature/`, `chore/`, `ci/`, `docs/`, `release/`).
+3. Open a PR back to `master`. CI (`Unit Tests`) must be green and at least 1 review must approve before merge.
+4. Releases are cut directly from `master`: bump version, update CHANGELOG/README on a `release/x.y.z` branch, PR to `master`, tag the merge commit, publish to pub.dev.
+5. The `develop` branch is retired. It will be deleted from the remote once any in-flight branches based on it have been rebased onto `master`.
+
+The PR metadata rules from ADR-005 still apply (template, project link, labels carried from linked issue), with two corrections:
+
+- **Base branch** is `master` (was `develop`).
+- **PR assignee** is `albertomarturelo` (was the non-existent login `AMarturelo`).
+
+## Alternatives Considered
+
+1. **Keep Git Flow as documented in ADR-005** — Rejected. The `develop` branch added a merge step without a corresponding benefit for a solo maintainer with frequent releases, and the divergence between documented process and actual practice was a source of confusion.
+2. **Trunk-based development with feature flags** — Rejected. The library is small enough that PR-gated review on `master` is sufficient, and feature-flag infrastructure would be over-engineering at the current scale.
+3. **Release branches as long-lived stabilization branches** — Rejected. Hotfixes to released versions can be handled by tagging from `master` or by short-lived `release/x.y.z` branches; no need to keep them alive between releases.
+
+## Consequences
+
+- One less integration step per change; faster path from branch to release.
+- `master` must always be releasable, so PRs need to be small and CI must be trustworthy. The `Unit Tests` required status check enforces the second part.
+- Branch protection on `master` is now the single gate. There is no second-chance review on a downstream merge to `master` — every PR is the production merge.
+- Documentation in `CLAUDE.md` and `CONVENTIONS.md` updated to reflect `master` as the base branch.
+- ADR-005 is marked Superseded for the base-branch and assignee sections; its label, template, and branch-naming rules remain in force.

--- a/doc/decisions/_index.md
+++ b/doc/decisions/_index.md
@@ -6,4 +6,5 @@
 | 002 | [Adapter pattern for zero dependencies](002-adapter-pattern-zero-dependencies.md) | Accepted | 2026-02-16 |
 | 003 | [Platform policy as independent safety layer](003-platform-policy-safety-layer.md) | Accepted | 2026-02-16 |
 | 004 | [Adopt Context-First Development](004-adopt-context-first-development.md) | Accepted | 2026-03-04 |
-| 005 | [GitHub Workflow Conventions](005-github-workflow-conventions.md) | Accepted | 2026-03-04 |
+| 005 | [GitHub Workflow Conventions](005-github-workflow-conventions.md) | Superseded by 006 | 2026-03-04 |
+| 006 | [Adopt GitHub Flow](006-adopt-github-flow.md) | Accepted | 2026-06-04 |


### PR DESCRIPTION
## Summary

- Add **ADR-006: Adopt GitHub Flow** superseding ADR-005 on the base-branch and assignee sections (labels/template/branch-naming rules from ADR-005 still apply).
- Update `doc/CONVENTIONS.md` and `CLAUDE.md` so PRs target `master` instead of `develop`.
- Fix PR assignee from the non-existent login `AMarturelo` to the real one, `albertomarturelo`.
- Document the active branch protection on `master` so it's discoverable from `CONVENTIONS.md`.

## Why

The repo already operates on `master` (branch protection applied, PR #33 merged directly there) but the docs still pointed contributors to `develop`. Aligns documentation with actual practice and removes friction for the next PR.

## Follow-ups (not in this PR)

- Delete the remote `develop` branch once any in-flight branches are rebased.
- Consider whether `release/x.y.z` branches should be kept as a convention or replaced with direct version PRs.

## Test plan

- [ ] CI green on the `Unit Tests` check
- [ ] ADR-006 renders correctly in `doc/decisions/_index.md`